### PR TITLE
fix: preserve CSV import header compatibility and CI install strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,12 @@ jobs:
 
       - name: Install frontend dependencies
         working-directory: frontend
-        run: npm install --no-package-lock
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install --no-package-lock
+          fi
 
       - name: Build frontend
         working-directory: frontend

--- a/backend/src/main/java/com/pocketfinance/backend/service/CsvService.java
+++ b/backend/src/main/java/com/pocketfinance/backend/service/CsvService.java
@@ -19,6 +19,7 @@ import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
@@ -63,7 +64,7 @@ public class CsvService {
         Map<String, Category> categoryCache = new HashMap<>();
 
         CSVFormat format = CSVFormat.DEFAULT.builder()
-                .setHeader("date", "description", "amount", "type", "category")
+                .setHeader()
                 .setSkipHeaderRecord(true)
                 .setIgnoreHeaderCase(true)
                 .setIgnoreEmptyLines(true)
@@ -72,6 +73,7 @@ public class CsvService {
 
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(file.getInputStream(), StandardCharsets.UTF_8));
              CSVParser parser = format.parse(reader)) {
+            validateCsvHeaders(parser);
 
             for (CSVRecord record : parser) {
                 try {
@@ -139,6 +141,17 @@ public class CsvService {
             throw new BadRequestException("Coluna obrigatoria ausente: " + column);
         }
         return value;
+    }
+
+    private void validateCsvHeaders(CSVParser parser) {
+        Map<String, Integer> headers = parser.getHeaderMap();
+        Set<String> requiredHeaders = Set.of("date", "description", "amount", "type", "category");
+
+        for (String header : requiredHeaders) {
+            if (!headers.containsKey(header)) {
+                throw new BadRequestException("CSV invalido. Cabecalho obrigatorio ausente: " + header);
+            }
+        }
     }
 
     private String colorFromName(String name) {


### PR DESCRIPTION
Resumo: restaura compatibilidade do import CSV por nome de cabecalho (sem assumir ordem fixa), valida cabecalhos obrigatorios explicitamente e ajusta a CI do frontend para usar npm ci quando existir package-lock.json com fallback para npm install --no-package-lock. Validacao executada: docker compose -f compose.dev.yml exec -T backend mvn -DskipTests compile.