### PR TITLE
feat: add proactive auth refresh and auth unit tests

### DIFF
--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -1,10 +1,12 @@
 import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AppComponent],
+      providers: [provideRouter([])]
     }).compileComponents();
   });
 
@@ -14,16 +16,10 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have the 'frontend' title`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('frontend');
-  });
-
-  it('should render title', () => {
+  it('should render the router outlet host', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, frontend');
+    expect(compiled.querySelector('router-outlet')).not.toBeNull();
   });
 });

--- a/frontend/src/app/core/auth/auth.interceptor.spec.ts
+++ b/frontend/src/app/core/auth/auth.interceptor.spec.ts
@@ -1,0 +1,113 @@
+import { HttpClient, HttpErrorResponse, provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { of } from 'rxjs';
+import { AuthSession } from './auth.models';
+import { AuthService } from './auth.service';
+import { authInterceptor } from './auth.interceptor';
+
+describe('authInterceptor', () => {
+  let http: HttpClient;
+  let httpMock: HttpTestingController;
+  let authServiceSpy: jasmine.SpyObj<AuthService>;
+  let routerSpy: jasmine.SpyObj<Router>;
+
+  beforeEach(() => {
+    authServiceSpy = jasmine.createSpyObj<AuthService>('AuthService', [
+      'accessToken',
+      'refreshToken',
+      'refreshSession',
+      'clearSession'
+    ]);
+    routerSpy = jasmine.createSpyObj<Router>('Router', ['navigateByUrl']);
+    routerSpy.navigateByUrl.and.resolveTo(true);
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([authInterceptor])),
+        provideHttpClientTesting(),
+        { provide: AuthService, useValue: authServiceSpy },
+        { provide: Router, useValue: routerSpy }
+      ]
+    });
+
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should attach bearer token to /api requests', () => {
+    authServiceSpy.accessToken.and.returnValue('access-1');
+
+    http.get('/api/me').subscribe();
+
+    const req = httpMock.expectOne('/api/me');
+    expect(req.request.headers.get('Authorization')).toBe('Bearer access-1');
+    req.flush({ ok: true });
+  });
+
+  it('should not attach token to login endpoint', () => {
+    authServiceSpy.accessToken.and.returnValue('access-1');
+
+    http.post('/api/auth/login', {}).subscribe();
+
+    const req = httpMock.expectOne('/api/auth/login');
+    expect(req.request.headers.has('Authorization')).toBeFalse();
+    req.flush({ ok: true });
+  });
+
+  it('should refresh and retry once on 401', () => {
+    authServiceSpy.accessToken.and.returnValues('expired-access', 'fresh-access');
+    authServiceSpy.refreshToken.and.returnValue('refresh-1');
+    authServiceSpy.refreshSession.and.returnValue(
+      of({
+        tokenType: 'Bearer',
+        accessToken: 'fresh-access',
+        refreshToken: 'refresh-2',
+        expiresAt: Date.now() + 60_000,
+        user: { id: 'u1', email: 'demo@pocket.local', fullName: 'Demo User' }
+      } satisfies AuthSession)
+    );
+
+    let responseBody: unknown;
+    http.get('/api/me').subscribe((response) => {
+      responseBody = response;
+    });
+
+    const first = httpMock.expectOne('/api/me');
+    expect(first.request.headers.get('Authorization')).toBe('Bearer expired-access');
+    first.flush({ message: 'Unauthorized' }, { status: 401, statusText: 'Unauthorized' });
+
+    expect(authServiceSpy.refreshSession).toHaveBeenCalledTimes(1);
+
+    const retry = httpMock.expectOne('/api/me');
+    expect(retry.request.headers.get('Authorization')).toBe('Bearer fresh-access');
+    retry.flush({ id: 'u1' });
+
+    expect(responseBody).toEqual({ id: 'u1' });
+  });
+
+  it('should clear session and redirect when 401 occurs without refresh token', () => {
+    authServiceSpy.accessToken.and.returnValue('expired-access');
+    authServiceSpy.refreshToken.and.returnValue(null);
+
+    let receivedError: HttpErrorResponse | null = null;
+    http.get('/api/me').subscribe({
+      error: (error) => {
+        receivedError = error;
+      }
+    });
+
+    const first = httpMock.expectOne('/api/me');
+    first.flush({ message: 'Unauthorized' }, { status: 401, statusText: 'Unauthorized' });
+
+    expect(authServiceSpy.clearSession).toHaveBeenCalled();
+    expect(routerSpy.navigateByUrl).toHaveBeenCalledWith('/login');
+    expect(receivedError).not.toBeNull();
+    expect((receivedError as unknown as HttpErrorResponse).status).toBe(401);
+  });
+});

--- a/frontend/src/app/core/auth/auth.service.spec.ts
+++ b/frontend/src/app/core/auth/auth.service.spec.ts
@@ -1,0 +1,121 @@
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { API_BASE_URL } from '../api/api.config';
+import { AuthResponse } from './auth.models';
+import { AuthService } from './auth.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    localStorage.clear();
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: API_BASE_URL, useValue: '/api' }
+      ]
+    });
+
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    localStorage.clear();
+  });
+
+  it('should persist session on login', async () => {
+    service = TestBed.inject(AuthService);
+    const loginPromise = firstValueFrom(service.login({ email: 'demo@pocket.local', password: 'demo123' }));
+
+    const req = httpMock.expectOne('/api/auth/login');
+    expect(req.request.method).toBe('POST');
+    req.flush(buildAuthResponse({ accessToken: 'access-1', refreshToken: 'refresh-1' }));
+
+    const session = await loginPromise;
+    expect(session.accessToken).toBe('access-1');
+    expect(service.accessToken()).toBe('access-1');
+    expect(service.refreshToken()).toBe('refresh-1');
+
+    const stored = localStorage.getItem('pocket_finance_auth_session');
+    expect(stored).toContain('access-1');
+    expect(service.hasSession()).toBeTrue();
+  });
+
+  it('should bootstrap session by refreshing when /me returns 401', async () => {
+    localStorage.setItem(
+      'pocket_finance_auth_session',
+      JSON.stringify({
+        tokenType: 'Bearer',
+        accessToken: 'expired-access',
+        refreshToken: 'refresh-1',
+        expiresAt: Date.now() - 1_000,
+        user: { id: 'u1', email: 'old@pocket.local', fullName: 'Old Name' }
+      })
+    );
+
+    service = TestBed.inject(AuthService);
+
+    const bootstrapPromise = firstValueFrom(service.bootstrapSession());
+
+    const meRequest = httpMock.expectOne('/api/me');
+    meRequest.flush({ message: 'Unauthorized' }, { status: 401, statusText: 'Unauthorized' });
+
+    const refreshRequest = httpMock.expectOne('/api/auth/refresh');
+    expect(refreshRequest.request.body).toEqual({ refreshToken: 'refresh-1' });
+    refreshRequest.flush(buildAuthResponse({ accessToken: 'access-2', refreshToken: 'refresh-2' }));
+
+    const meRetry = httpMock.expectOne('/api/me');
+    meRetry.flush({ id: 'u1', email: 'demo@pocket.local', fullName: 'Demo User' });
+
+    await bootstrapPromise;
+
+    expect(service.accessToken()).toBe('access-2');
+    expect(service.refreshToken()).toBe('refresh-2');
+    expect(service.user()?.email).toBe('demo@pocket.local');
+  });
+
+  it('should refresh proactively before token expiration', fakeAsync(() => {
+    service = TestBed.inject(AuthService);
+    let loginCompleted = false;
+    service.login({ email: 'demo@pocket.local', password: 'demo123' }).subscribe(() => {
+      loginCompleted = true;
+    });
+
+    httpMock.expectOne('/api/auth/login').flush(
+      buildAuthResponse({ accessToken: 'access-1', refreshToken: 'refresh-1', expiresIn: 120 })
+    );
+    expect(loginCompleted).toBeTrue();
+
+    tick(59_000);
+    httpMock.expectNone('/api/auth/refresh');
+
+    tick(1_000);
+    const refreshRequest = httpMock.expectOne('/api/auth/refresh');
+    refreshRequest.flush(buildAuthResponse({ accessToken: 'access-2', refreshToken: 'refresh-2', expiresIn: 120 }));
+
+    expect(service.accessToken()).toBe('access-2');
+    expect(service.refreshToken()).toBe('refresh-2');
+    service.clearSession();
+  }));
+});
+
+function buildAuthResponse(overrides: Partial<AuthResponse> = {}): AuthResponse {
+  return {
+    tokenType: 'Bearer',
+    accessToken: 'access-token',
+    refreshToken: 'refresh-token',
+    expiresIn: 900,
+    user: {
+      id: 'u1',
+      email: 'demo@pocket.local',
+      fullName: 'Demo User'
+    },
+    ...overrides
+  };
+}


### PR DESCRIPTION
Resumo: adiciona refresh proativo de sessao baseado em expiresAt no AuthService e inclui testes unitarios para AuthService/authInterceptor (incluindo retry em 401). Tambem corrige o spec legado do AppComponent. Validacoes locais: ng build OK; ng test compila a suite, mas a execucao no container falha por ausencia de ChromeHeadless (CHROME_BIN).