### PR TITLE
test: cover CSV import and category service edge cases

### DIFF
--- a/backend/src/test/java/com/pocketfinance/backend/service/CategoryServiceTest.java
+++ b/backend/src/test/java/com/pocketfinance/backend/service/CategoryServiceTest.java
@@ -1,0 +1,103 @@
+package com.pocketfinance.backend.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.pocketfinance.backend.api.dto.CategoryResponse;
+import com.pocketfinance.backend.api.dto.CategoryUpdateRequest;
+import com.pocketfinance.backend.domain.model.Category;
+import com.pocketfinance.backend.domain.model.User;
+import com.pocketfinance.backend.domain.repository.CategoryRepository;
+import com.pocketfinance.backend.domain.repository.UserRepository;
+import com.pocketfinance.backend.exception.BadRequestException;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@ExtendWith(MockitoExtension.class)
+class CategoryServiceTest {
+
+    @Mock
+    private CategoryRepository categoryRepository;
+    @Mock
+    private UserRepository userRepository;
+
+    private CategoryService categoryService;
+    private UUID userId;
+    private UUID categoryId;
+
+    @BeforeEach
+    void setUp() {
+        categoryService = new CategoryService(categoryRepository, userRepository);
+        userId = UUID.randomUUID();
+        categoryId = UUID.randomUUID();
+    }
+
+    @Test
+    void updateShouldRejectDuplicateNameFromAnotherCategory() {
+        Category current = category(categoryId, "Mercado", "#00FF00");
+        Category duplicate = category(UUID.randomUUID(), "Mercado", "#FF0000");
+
+        when(categoryRepository.findByIdAndUserId(categoryId, userId)).thenReturn(Optional.of(current));
+        when(categoryRepository.findByUserIdAndNameIgnoreCase(userId, "Alimentacao")).thenReturn(Optional.of(duplicate));
+
+        BadRequestException exception = assertThrows(
+                BadRequestException.class,
+                () -> categoryService.update(userId, categoryId, new CategoryUpdateRequest(" Alimentacao ", " #123456 "))
+        );
+
+        assertEquals("Categoria ja existe para este usuario.", exception.getMessage());
+        verify(categoryRepository, never()).save(any(Category.class));
+    }
+
+    @Test
+    void updateShouldAllowSameNameForSameCategoryAndTrimFields() {
+        Category current = category(categoryId, "Mercado", "#00FF00");
+
+        when(categoryRepository.findByIdAndUserId(categoryId, userId)).thenReturn(Optional.of(current));
+        when(categoryRepository.findByUserIdAndNameIgnoreCase(userId, "Mercado")).thenReturn(Optional.of(current));
+        when(categoryRepository.save(current)).thenReturn(current);
+
+        CategoryResponse response = categoryService.update(userId, categoryId, new CategoryUpdateRequest(" Mercado ", " #123456 "));
+
+        assertEquals(categoryId, response.id());
+        assertEquals("Mercado", response.name());
+        assertEquals("#123456", response.color());
+        verify(categoryRepository).save(current);
+    }
+
+    @Test
+    void deleteShouldWrapIntegrityViolationAsBadRequest() {
+        Category current = category(categoryId, "Moradia", "#112233");
+        when(categoryRepository.findByIdAndUserId(categoryId, userId)).thenReturn(Optional.of(current));
+        doThrow(new DataIntegrityViolationException("fk_violation")).when(categoryRepository).flush();
+
+        BadRequestException exception = assertThrows(BadRequestException.class, () -> categoryService.delete(userId, categoryId));
+
+        assertEquals("Nao foi possivel excluir categoria com transacoes ou metas vinculadas.", exception.getMessage());
+        verify(categoryRepository).delete(current);
+        verify(categoryRepository).flush();
+    }
+
+    private Category category(UUID id, String name, String color) {
+        User user = new User();
+        user.setId(userId);
+
+        Category category = new Category();
+        category.setId(id);
+        category.setUser(user);
+        category.setName(name);
+        category.setColor(color);
+        return category;
+    }
+}

--- a/backend/src/test/java/com/pocketfinance/backend/service/CsvServiceTest.java
+++ b/backend/src/test/java/com/pocketfinance/backend/service/CsvServiceTest.java
@@ -1,0 +1,113 @@
+package com.pocketfinance.backend.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.pocketfinance.backend.api.dto.CsvImportResponse;
+import com.pocketfinance.backend.domain.model.Category;
+import com.pocketfinance.backend.domain.model.FinanceTransaction;
+import com.pocketfinance.backend.domain.model.TransactionType;
+import com.pocketfinance.backend.domain.model.User;
+import com.pocketfinance.backend.domain.repository.FinanceTransactionRepository;
+import com.pocketfinance.backend.domain.repository.UserRepository;
+import com.pocketfinance.backend.exception.BadRequestException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+class CsvServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private CategoryService categoryService;
+    @Mock
+    private FinanceTransactionRepository transactionRepository;
+    @Mock
+    private TransactionService transactionService;
+
+    private CsvService csvService;
+    private UUID userId;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        csvService = new CsvService(userRepository, categoryService, transactionRepository, transactionService);
+        userId = UUID.randomUUID();
+        user = new User();
+        user.setId(userId);
+    }
+
+    @Test
+    void importSimpleCsvShouldAcceptReorderedHeadersByName() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        Category category = new Category();
+        category.setId(UUID.randomUUID());
+        category.setName("Alimentacao");
+        category.setColor("#33CCAA");
+        when(categoryService.findOrCreateByName(eq(userId), eq("Alimentacao"), anyString())).thenReturn(category);
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "transactions.csv",
+                "text/csv",
+                """
+                amount,date,category,type,description
+                123.45,2026-02-26,Alimentacao,expense,Supermercado
+                """.getBytes()
+        );
+
+        CsvImportResponse response = csvService.importSimpleCsv(userId, file);
+
+        assertEquals(1, response.imported());
+        assertEquals(0, response.skipped());
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<FinanceTransaction>> captor = ArgumentCaptor.forClass(List.class);
+        verify(transactionRepository).saveAll(captor.capture());
+
+        FinanceTransaction saved = captor.getValue().getFirst();
+        assertEquals(user, saved.getUser());
+        assertEquals(category, saved.getCategory());
+        assertEquals(TransactionType.EXPENSE, saved.getType());
+        assertEquals("Supermercado", saved.getDescription());
+        assertEquals(new BigDecimal("123.45"), saved.getAmount());
+        assertEquals(LocalDate.of(2026, 2, 26), saved.getDate());
+    }
+
+    @Test
+    void importSimpleCsvShouldFailWhenRequiredHeaderIsMissing() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "invalid.csv",
+                "text/csv",
+                """
+                date,description,amount,type
+                2026-02-26,Sem categoria,10.00,EXPENSE
+                """.getBytes()
+        );
+
+        BadRequestException exception = assertThrows(BadRequestException.class, () -> csvService.importSimpleCsv(userId, file));
+        assertEquals("CSV invalido. Cabecalho obrigatorio ausente: category", exception.getMessage());
+        verify(transactionRepository, never()).saveAll(anyList());
+    }
+}


### PR DESCRIPTION
## Summary
- add CsvService tests for reordered/missing headers
- add CategoryService tests for update/delete edge cases
- protect regressions introduced in recent CSV/category fixes

## Validation
- docker compose -f compose.dev.yml exec -T backend mvn "-Dtest=CsvServiceTest,CategoryServiceTest" test
