### PR TITLE
feat: add CSV import and export to transactions UI

### DIFF
--- a/frontend/src/app/core/api/finance.models.ts
+++ b/frontend/src/app/core/api/finance.models.ts
@@ -61,6 +61,16 @@ export interface TransactionListQuery {
   page?: number;
 }
 
+export interface CsvImportResponse {
+  imported: number;
+  skipped: number;
+}
+
+export interface CsvExportQuery {
+  month?: string | null;
+  category?: string | null;
+}
+
 export interface Budget {
   id: string;
   categoryId: string;

--- a/frontend/src/app/core/api/reports.service.ts
+++ b/frontend/src/app/core/api/reports.service.ts
@@ -1,0 +1,34 @@
+import { HttpClient, HttpParams, HttpResponse } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { API_BASE_URL } from './api.config';
+import { CsvExportQuery, CsvImportResponse } from './finance.models';
+
+@Injectable({ providedIn: 'root' })
+export class ReportsService {
+  private readonly http = inject(HttpClient);
+  private readonly apiBaseUrl = inject(API_BASE_URL);
+
+  importCsv(file: File): Observable<CsvImportResponse> {
+    const formData = new FormData();
+    formData.append('file', file);
+
+    return this.http.post<CsvImportResponse>(`${this.apiBaseUrl}/import/csv`, formData);
+  }
+
+  exportCsv(query: CsvExportQuery = {}): Observable<HttpResponse<Blob>> {
+    let params = new HttpParams();
+    if (query.month) {
+      params = params.set('month', query.month);
+    }
+    if (query.category) {
+      params = params.set('category', query.category);
+    }
+
+    return this.http.get(`${this.apiBaseUrl}/export/csv`, {
+      params,
+      observe: 'response',
+      responseType: 'blob'
+    });
+  }
+}

--- a/frontend/src/app/pages/transactions-page.component.css
+++ b/frontend/src/app/pages/transactions-page.component.css
@@ -2,6 +2,31 @@
   padding: 1rem;
 }
 
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.header-actions__import {
+  position: relative;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.header-actions__import input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.header-actions__import.is-disabled {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
 .filters,
 .editor {
   display: grid;
@@ -148,6 +173,10 @@
 }
 
 @media (max-width: 720px) {
+  .header-actions {
+    width: 100%;
+  }
+
   .filters,
   .editor {
     grid-template-columns: 1fr;

--- a/frontend/src/app/pages/transactions-page.component.html
+++ b/frontend/src/app/pages/transactions-page.component.html
@@ -3,7 +3,16 @@
     <div class="pf-card__header">
       <div>
         <h2 class="pf-card__title">Transacoes</h2>
-        <p class="pf-card__subtitle">Listagem paginada + filtros + CRUD real.</p>
+        <p class="pf-card__subtitle">Listagem paginada + filtros + CRUD real + import/export CSV.</p>
+      </div>
+      <div class="header-actions">
+        <button class="pf-btn" type="button" (click)="exportCsv()" [disabled]="isExporting()">
+          {{ isExporting() ? 'Exportando...' : 'Exportar CSV' }}
+        </button>
+        <label class="pf-btn pf-btn--primary header-actions__import" [class.is-disabled]="isImporting()">
+          <span>{{ isImporting() ? 'Importando...' : 'Importar CSV' }}</span>
+          <input type="file" accept=".csv,text/csv" (change)="importCsv($event)" [disabled]="isImporting()" />
+        </label>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- add frontend reports service for CSV import/export endpoints
- wire import/export actions into transactions page
- add UI feedback states for importing/exporting

## Validation
- docker compose -f compose.dev.yml exec -T frontend npm run build
