### PR TITLE
feat: persist transaction filters in URL

### DIFF
--- a/frontend/src/app/pages/transactions-page.component.html
+++ b/frontend/src/app/pages/transactions-page.component.html
@@ -3,7 +3,7 @@
     <div class="pf-card__header">
       <div>
         <h2 class="pf-card__title">Transacoes</h2>
-        <p class="pf-card__subtitle">Listagem paginada + filtros + CRUD real + import/export CSV.</p>
+        <p class="pf-card__subtitle">Listagem paginada + filtros persistidos na URL + CRUD real + import/export CSV.</p>
       </div>
       <div class="header-actions">
         <button class="pf-btn" type="button" (click)="exportCsv()" [disabled]="isExporting()">


### PR DESCRIPTION
## Summary
- restore transaction filters/page from query params on load
- sync filter and page state back to URL on listing requests
- preserve shareable/reloadable transaction views

## Validation
- docker compose -f compose.dev.yml exec -T frontend npm run build
