### PR TITLE
feat: improve budgets month navigation and validation UX

### DIFF
--- a/frontend/src/app/pages/budgets-page.component.css
+++ b/frontend/src/app/pages/budgets-page.component.css
@@ -28,8 +28,20 @@
   grid-template-columns: 1fr auto;
 }
 
+.budgets__month-nav {
+  grid-column: 1 / -1;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
 .budgets__create {
   grid-template-columns: 1.4fr 1fr auto;
+}
+
+.budgets__create-error {
+  margin-top: 0.25rem;
+  margin-bottom: 0;
 }
 
 .budgets label {
@@ -92,6 +104,21 @@
   font-size: 0.82rem;
 }
 
+.budget-row__status {
+  margin: 0.35rem 0 0;
+  color: rgba(82, 214, 165, 0.9);
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.budget-row__status--warn {
+  color: #ffd685;
+}
+
+.budget-row__status--danger {
+  color: #ff9e8f;
+}
+
 .budget-row__edit {
   display: flex;
   align-items: center;
@@ -108,6 +135,10 @@
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.08);
   overflow: hidden;
+}
+
+.budget-row__error {
+  margin: 0 0 0.5rem;
 }
 
 .budget-row__fill {
@@ -131,6 +162,10 @@
 }
 
 @media (max-width: 720px) {
+  .budgets__month-nav {
+    flex-direction: column;
+  }
+
   .budget-row__head {
     flex-direction: column;
     align-items: flex-start;

--- a/frontend/src/app/pages/budgets-page.component.html
+++ b/frontend/src/app/pages/budgets-page.component.html
@@ -3,7 +3,7 @@
     <div class="pf-card__header">
       <div>
         <h2 class="pf-card__title">Metas por categoria</h2>
-        <p class="pf-card__subtitle">Metas reais com progresso calculado pelas despesas do mes.</p>
+        <p class="pf-card__subtitle">Metas reais com progresso por despesas do mes e navegacao mensal rapida.</p>
       </div>
       <div class="budgets__totals pf-mono">
         <span>Total usado: {{ totalUsed() | currency: 'BRL' : 'symbol' : '1.2-2' : 'pt-BR' }}</span>
@@ -13,6 +13,11 @@
 
     <div class="budgets__toolbar">
       <form class="budgets__month" [formGroup]="monthForm" (ngSubmit)="reload()">
+        <div class="budgets__month-nav">
+          <button class="pf-btn" type="button" (click)="previousMonth()">Mes anterior</button>
+          <button class="pf-btn" type="button" (click)="currentMonth()">Mes atual</button>
+          <button class="pf-btn" type="button" (click)="nextMonth()">Proximo mes</button>
+        </div>
         <label>
           <span>Mes</span>
           <input type="month" formControlName="month" />
@@ -38,6 +43,9 @@
           {{ isCreating() ? 'Criando...' : 'Criar meta' }}
         </button>
       </form>
+      @if (createFormError()) {
+        <p class="pf-inline-error budgets__create-error" role="alert">{{ createFormError() }}</p>
+      }
     </div>
 
     @if (loadError()) {
@@ -59,6 +67,9 @@
                   {{ budgetUsage(budget.categoryId) | currency: 'BRL' : 'symbol' : '1.2-2' : 'pt-BR' }} /
                   {{ budget.amount | currency: 'BRL' : 'symbol' : '1.2-2' : 'pt-BR' }}
                 </p>
+                <p class="budget-row__status" [class.budget-row__status--warn]="budgetIsWarn(budget)" [class.budget-row__status--danger]="budgetIsExceeded(budget)">
+                  {{ budgetStatusText(budget) }}
+                </p>
               </div>
               <div class="budget-row__edit">
                 <input
@@ -74,6 +85,9 @@
                 </button>
               </div>
             </div>
+            @if (draftError(budget.id)) {
+              <p class="pf-inline-error budget-row__error" role="alert">{{ draftError(budget.id) }}</p>
+            }
 
             <div class="budget-row__track" aria-hidden="true">
               <div


### PR DESCRIPTION
## Summary
- add previous/current/next month controls on budgets page
- improve create/update validation messages for budgets
- add budget status labels (within target / near limit / exceeded)

## Validation
- docker compose -f compose.dev.yml exec -T frontend npm run build
