### PR TITLE
feat: persist budgets month filter in URL

### DIFF
--- a/frontend/src/app/pages/budgets-page.component.html
+++ b/frontend/src/app/pages/budgets-page.component.html
@@ -3,7 +3,7 @@
     <div class="pf-card__header">
       <div>
         <h2 class="pf-card__title">Metas por categoria</h2>
-        <p class="pf-card__subtitle">Metas reais com progresso por despesas do mes e navegacao mensal rapida.</p>
+        <p class="pf-card__subtitle">Metas reais com progresso por despesas do mes, navegacao mensal rapida e URL compartilhavel.</p>
       </div>
       <div class="budgets__totals pf-mono">
         <span>Total usado: {{ totalUsed() | currency: 'BRL' : 'symbol' : '1.2-2' : 'pt-BR' }}</span>


### PR DESCRIPTION
## Summary
- restore budgets month from query params on page load
- sync selected month back to URL on reload/navigation actions
- keep budgets views shareable and refresh-safe

## Validation
- docker compose -f compose.dev.yml exec -T frontend npm run build
