### PR TITLE
feat: add CSV template download to transactions page

### DIFF
--- a/frontend/src/app/pages/transactions-page.component.html
+++ b/frontend/src/app/pages/transactions-page.component.html
@@ -6,6 +6,7 @@
         <p class="pf-card__subtitle">Listagem paginada + filtros persistidos na URL + CRUD real + import/export CSV.</p>
       </div>
       <div class="header-actions">
+        <button class="pf-btn" type="button" (click)="downloadCsvTemplate()">Modelo CSV</button>
         <button class="pf-btn" type="button" (click)="exportCsv()" [disabled]="isExporting()">
           {{ isExporting() ? 'Exportando...' : 'Exportar CSV' }}
         </button>

--- a/frontend/src/app/pages/transactions-page.component.ts
+++ b/frontend/src/app/pages/transactions-page.component.ts
@@ -230,6 +230,17 @@ export class TransactionsPageComponent {
       });
   }
 
+  protected downloadCsvTemplate(): void {
+    const template = [
+      'date,description,amount,type,category',
+      '2026-02-26,Supermercado,123.45,expense,Alimentacao',
+      '2026-02-27,Salario,3500.00,income,Renda'
+    ].join('\n');
+
+    this.downloadBlob(new Blob([template], { type: 'text/csv;charset=utf-8' }), 'transactions-template.csv');
+    this.toastService.info('Modelo CSV baixado.');
+  }
+
   protected trackByTransactionId = (_: number, item: Transaction) => item.id;
 
   protected currentPage(): number {


### PR DESCRIPTION
## Summary
- add CSV template download button to transactions page
- provide example rows with the expected header order for imports
- reuse existing download helper/toast feedback

## Validation
- docker compose -f compose.dev.yml exec -T frontend npm run build
