### PR TITLE
chore: add frontend CI-like local scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,10 @@ Para a action criar PRs/releases automaticamente, o repositório precisa permiti
   - `frontend`: `npm run build`
 - O Angular usa budgets de bundle/estilo para sinalizar crescimento excessivo.
 - Os limites de `anyComponentStyle` foram ajustados para um patamar mais realista do layout atual, mantendo alerta sem gerar ruído excessivo no dia a dia.
+
+### Comandos uteis no frontend
+
+Dentro de `frontend/`:
+
+- `npm run build:ci` -> build de producao (mesmo alvo usado na CI)
+- `npm run spec:check` -> valida tipagem/compilacao dos testes (`*.spec.ts`) sem precisar de Chrome

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,8 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
+    "build:ci": "ng build --configuration production",
+    "spec:check": "tsc -p tsconfig.spec.json --noEmit",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"
   },


### PR DESCRIPTION
## Summary
- add frontend scripts for CI-like build and spec type-check
- document the new commands in README
- make local validation easier without requiring browser test runtime

## Validation
- docker compose -f compose.dev.yml exec -T frontend npm run spec:check
- docker compose -f compose.dev.yml exec -T frontend npm run build:ci
