### PR TITLE
test: add frontend coverage for health service

### DIFF
--- a/frontend/src/app/core/api/health.service.spec.ts
+++ b/frontend/src/app/core/api/health.service.spec.ts
@@ -1,0 +1,38 @@
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
+import { API_BASE_URL } from './api.config';
+import { HealthService } from './health.service';
+
+describe('HealthService', () => {
+  let service: HealthService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: API_BASE_URL, useValue: '/api' }
+      ]
+    });
+
+    service = TestBed.inject(HealthService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should request backend actuator health', async () => {
+    const promise = firstValueFrom(service.getHealth());
+
+    const req = httpMock.expectOne('/api/actuator/health');
+    expect(req.request.method).toBe('GET');
+    req.flush({ status: 'UP' });
+
+    await expectAsync(promise).toBeResolvedTo({ status: 'UP' });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for HealthService backend actuator request
- verify GET /api/actuator/health route and response mapping

## Validation
- docker compose -f compose.dev.yml exec -T frontend npm run spec:check
