### PR TITLE
test: add frontend coverage for HTTP activity service

### DIFF
--- a/frontend/src/app/core/http/http-activity.service.spec.ts
+++ b/frontend/src/app/core/http/http-activity.service.spec.ts
@@ -1,0 +1,37 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpActivityService } from './http-activity.service';
+
+describe('HttpActivityService', () => {
+  let service: HttpActivityService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(HttpActivityService);
+  });
+
+  it('should track pending request count and busy state', () => {
+    expect(service.pendingCount()).toBe(0);
+    expect(service.isBusy()).toBeFalse();
+
+    service.begin();
+    service.begin();
+
+    expect(service.pendingCount()).toBe(2);
+    expect(service.isBusy()).toBeTrue();
+
+    service.end();
+    expect(service.pendingCount()).toBe(1);
+
+    service.end();
+    expect(service.pendingCount()).toBe(0);
+    expect(service.isBusy()).toBeFalse();
+  });
+
+  it('should not go below zero', () => {
+    service.end();
+    service.end();
+
+    expect(service.pendingCount()).toBe(0);
+    expect(service.isBusy()).toBeFalse();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for HttpActivityService counters and computed busy state
- verify underflow protection (count never goes below zero)

## Validation
- docker compose -f compose.dev.yml exec -T frontend npm run spec:check
