### PR TITLE
chore: add dev status script for docker stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ powershell -ExecutionPolicy Bypass -File .\scripts\smoke-dev.ps1 `
   -BackendUrl "http://localhost:18080"
 ```
 
+Status rapido da stack (containers + URLs):
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\dev-status.ps1
+```
+
 ### Inicializar automaticamente com o Docker
 
 Os serviços no `compose.dev.yml` usam `restart: unless-stopped`. Isso significa:

--- a/scripts/dev-status.ps1
+++ b/scripts/dev-status.ps1
@@ -1,0 +1,18 @@
+param(
+  [string]$ComposeFile = "compose.dev.yml",
+  [string]$FrontendUrl = "http://localhost:34200",
+  [string]$BackendUrl = "http://localhost:38080"
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "== Docker Compose services =="
+docker compose -f $ComposeFile ps
+
+Write-Host ""
+Write-Host "== Endpoints =="
+Write-Host "Frontend: $FrontendUrl"
+Write-Host "Backend:  $BackendUrl"
+Write-Host "Swagger:  $BackendUrl/swagger-ui/index.html"
+Write-Host "Health:   $BackendUrl/actuator/health"
+Write-Host "OpenAPI:  $BackendUrl/v3/api-docs"


### PR DESCRIPTION
## Summary
- add PowerShell script to show compose service status and local URLs
- document script usage in README near smoke test section

## Validation
- powershell -ExecutionPolicy Bypass -File .\scripts\dev-status.ps1
