### PR TITLE
chore: add dev logs script for docker services

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ Status rapido da stack (containers + URLs):
 powershell -ExecutionPolicy Bypass -File .\scripts\dev-status.ps1
 ```
 
+Logs rapidos por servico:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\dev-logs.ps1 -Service backend
+powershell -ExecutionPolicy Bypass -File .\scripts\dev-logs.ps1 -Service frontend
+powershell -ExecutionPolicy Bypass -File .\scripts\dev-logs.ps1 -Service backend -NoFollow -Tail 50
+```
+
 ### Inicializar automaticamente com o Docker
 
 Os serviços no `compose.dev.yml` usam `restart: unless-stopped`. Isso significa:

--- a/scripts/dev-logs.ps1
+++ b/scripts/dev-logs.ps1
@@ -1,0 +1,20 @@
+param(
+  [ValidateSet("frontend", "backend", "db")]
+  [string]$Service = "backend",
+  [string]$ComposeFile = "compose.dev.yml",
+  [switch]$NoFollow,
+  [int]$Tail = 100
+)
+
+$ErrorActionPreference = "Stop"
+
+$argsList = @("compose", "-f", $ComposeFile, "logs")
+if (-not $NoFollow) {
+  $argsList += "-f"
+}
+$argsList += "--tail"
+$argsList += "$Tail"
+$argsList += $Service
+
+Write-Host "Executando: docker $($argsList -join ' ')"
+docker @argsList


### PR DESCRIPTION
## Summary
- add PowerShell helper to tail docker compose logs by service
- support follow/no-follow and tail size parameters
- document examples in README

## Validation
- powershell -ExecutionPolicy Bypass -File .\scripts\dev-logs.ps1 -Service backend -NoFollow -Tail 5
