### PR TITLE
docs: add frontend test troubleshooting for container env

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,3 +186,12 @@ Dentro de `frontend/`:
 
 - `npm run build:ci` -> build de producao (mesmo alvo usado na CI)
 - `npm run spec:check` -> valida tipagem/compilacao dos testes (`*.spec.ts`) sem precisar de Chrome
+
+### Troubleshooting: testes frontend no container
+
+O comando `npm test` (Karma) pode falhar no container de desenvolvimento por falta de `ChromeHeadless` (`CHROME_BIN`).
+
+Quando isso acontecer:
+
+- use `npm run spec:check` para validar compilacao/tipagem dos testes rapidamente
+- execute `npm test` em um ambiente com Chrome/Chromium instalado (host local ou CI dedicada)


### PR DESCRIPTION
## Summary
- document why Angular/Karma tests may fail inside the dev container (missing ChromeHeadless)
- document fallback validation using npm run spec:check
