### PR TITLE
ci: run frontend spec type-check before build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,4 +54,6 @@ jobs:
 
       - name: Build frontend
         working-directory: frontend
-        run: npm run build
+        run: |
+          npm run spec:check
+          npm run build


### PR DESCRIPTION
## Summary
- run frontend spec type-check before Angular build in CI
- fail faster on broken *.spec.ts changes without requiring Chrome

## Validation
- docker compose -f compose.dev.yml exec -T frontend npm run spec:check
- docker compose -f compose.dev.yml exec -T frontend npm run build
