### PR TITLE
test: cover report export without filters

### DIFF
--- a/backend/src/test/java/com/pocketfinance/backend/api/controller/ReportControllerTest.java
+++ b/backend/src/test/java/com/pocketfinance/backend/api/controller/ReportControllerTest.java
@@ -66,4 +66,17 @@ class ReportControllerTest {
         assertArrayEquals(payload, response.getBody());
         verify(csvService).exportCsv(principal.getUserId(), "2026-02", categoryId);
     }
+
+    @Test
+    void exportCsvShouldAllowNullFilters() {
+        byte[] payload = "date,description\n".getBytes(StandardCharsets.UTF_8);
+        when(csvService.exportCsv(principal.getUserId(), null, null)).thenReturn(payload);
+
+        ResponseEntity<byte[]> response = controller.exportCsv(principal, null, null);
+
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals("text/csv", response.getHeaders().getContentType().toString());
+        assertArrayEquals(payload, response.getBody());
+        verify(csvService).exportCsv(principal.getUserId(), null, null);
+    }
 }


### PR DESCRIPTION
## Summary
- add ReportController test for CSV export without month/category filters
- verify default response headers and service delegation with null filters

## Validation
- docker compose -f compose.dev.yml exec -T backend mvn "-Dtest=ReportControllerTest" test
