### PR TITLE
ci: run frontend unit tests before build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,4 +56,5 @@ jobs:
         working-directory: frontend
         run: |
           npm run spec:check
+          npm run test:ci
           npm run build

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Dentro de `frontend/`:
 
 - `npm run build:ci` -> build de producao (mesmo alvo usado na CI)
 - `npm run spec:check` -> valida tipagem/compilacao dos testes (`*.spec.ts`) sem precisar de Chrome
+- `npm run test:ci` -> executa testes unitarios em `ChromeHeadless` (sem watch)
 
 ### Troubleshooting: testes frontend no container
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "build": "ng build",
     "build:ci": "ng build --configuration production",
     "spec:check": "tsc -p tsconfig.spec.json --noEmit",
+    "test:ci": "ng test --watch=false --browsers=ChromeHeadless --no-progress",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"
   },


### PR DESCRIPTION
## Summary
- add frontend test:ci script using Karma + ChromeHeadless
- run frontend spec:check + unit tests + build in CI
- document test:ci command in README

## Validation
- docker compose -f compose.dev.yml exec -T frontend npm run spec:check
- docker compose -f compose.dev.yml exec -T frontend npm run build
- docker compose -f compose.dev.yml exec -T frontend npm run test:ci (expected to fail in dev container without CHROME_BIN)
