### PR TITLE
feat: add dedicated reports page for CSV import and export

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -5,6 +5,7 @@ import { BudgetsPageComponent } from './pages/budgets-page.component';
 import { CategoriesPageComponent } from './pages/categories-page.component';
 import { DashboardPageComponent } from './pages/dashboard-page.component';
 import { LoginPageComponent } from './pages/login-page.component';
+import { ReportsPageComponent } from './pages/reports-page.component';
 import { TransactionsPageComponent } from './pages/transactions-page.component';
 
 export const routes: Routes = [
@@ -22,6 +23,7 @@ export const routes: Routes = [
       { path: '', pathMatch: 'full', redirectTo: 'dashboard' },
       { path: 'dashboard', component: DashboardPageComponent, title: 'Dashboard | Pocket Finance' },
       { path: 'transactions', component: TransactionsPageComponent, title: 'Transacoes | Pocket Finance' },
+      { path: 'reports', component: ReportsPageComponent, title: 'Relatorios | Pocket Finance' },
       { path: 'categories', component: CategoriesPageComponent, title: 'Categorias | Pocket Finance' },
       { path: 'budgets', component: BudgetsPageComponent, title: 'Metas | Pocket Finance' }
     ]

--- a/frontend/src/app/layout/shell-layout.component.ts
+++ b/frontend/src/app/layout/shell-layout.component.ts
@@ -31,6 +31,7 @@ export class ShellLayoutComponent {
   protected readonly navItems: NavItem[] = [
     { label: 'Dashboard', path: '/dashboard' },
     { label: 'Transacoes', path: '/transactions' },
+    { label: 'Relatorios', path: '/reports', badge: 'CSV' },
     { label: 'Categorias', path: '/categories' },
     { label: 'Metas', path: '/budgets', badge: 'MVP' }
   ];

--- a/frontend/src/app/pages/reports-page.component.css
+++ b/frontend/src/app/pages/reports-page.component.css
@@ -1,0 +1,132 @@
+.reports {
+  padding: 1rem;
+}
+
+.reports__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.reports__result {
+  margin: 0 0 0.75rem;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.reports__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.9rem;
+}
+
+.reports-card {
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 14px;
+  padding: 0.9rem;
+  background: rgba(255, 255, 255, 0.02);
+  display: grid;
+  gap: 0.75rem;
+  align-content: start;
+}
+
+.reports-card__header h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.reports-card__header p {
+  margin: 0.35rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.reports-card__steps {
+  margin: 0;
+  padding-left: 1rem;
+  color: var(--text-muted);
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.86rem;
+}
+
+.reports-upload {
+  position: relative;
+  border-radius: 12px;
+  border: 1px dashed rgba(82, 214, 165, 0.35);
+  background: rgba(82, 214, 165, 0.07);
+  color: var(--text);
+  padding: 0.85rem 0.9rem;
+  cursor: pointer;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+}
+
+.reports-upload input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.reports-upload--disabled {
+  opacity: 0.65;
+  pointer-events: none;
+}
+
+.reports-form {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.reports-form label {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.reports-form label span {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.reports-form input,
+.reports-form select {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text);
+  padding: 0.65rem 0.75rem;
+}
+
+.reports-form input:focus,
+.reports-form select:focus {
+  outline: 2px solid rgba(82, 214, 165, 0.25);
+  border-color: rgba(82, 214, 165, 0.35);
+}
+
+.reports-card__hint {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+}
+
+.reports-card__hint code {
+  font-family: var(--font-mono);
+  color: var(--text);
+}
+
+@media (max-width: 980px) {
+  .reports__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .reports__actions {
+    width: 100%;
+  }
+}

--- a/frontend/src/app/pages/reports-page.component.html
+++ b/frontend/src/app/pages/reports-page.component.html
@@ -1,0 +1,82 @@
+<section class="pf-page">
+  <article class="pf-card reports">
+    <div class="pf-card__header">
+      <div>
+        <h2 class="pf-card__title">Relatorios CSV</h2>
+        <p class="pf-card__subtitle">Importe transacoes em lote e exporte relatorios filtrados por mes/categoria.</p>
+      </div>
+      <div class="reports__actions">
+        <button class="pf-btn" type="button" (click)="downloadTemplate()">Modelo CSV</button>
+        <button class="pf-btn" type="button" (click)="reloadCategories()" [disabled]="isLoadingCategories()">
+          {{ isLoadingCategories() ? 'Atualizando...' : 'Atualizar categorias' }}
+        </button>
+      </div>
+    </div>
+
+    @if (pageError()) {
+      <p class="pf-inline-error" role="alert">{{ pageError() }}</p>
+    }
+
+    @if (lastImportResult()) {
+      <p class="reports__result pf-mono">
+        Ultima importacao: {{ lastImportResult()!.imported }} importadas · {{ lastImportResult()!.skipped }} ignoradas
+      </p>
+    }
+
+    <div class="reports__grid">
+      <section class="reports-card">
+        <header class="reports-card__header">
+          <h3>Importar CSV</h3>
+          <p>Envie um arquivo `.csv` com transacoes para importacao em lote.</p>
+        </header>
+
+        <ol class="reports-card__steps">
+          <li>Baixe o modelo CSV para usar o cabecalho esperado.</li>
+          <li>Preencha linhas com `date`, `description`, `amount`, `type`, `category`.</li>
+          <li>Envie o arquivo para importar no backend.</li>
+        </ol>
+
+        <label class="reports-upload" [class.reports-upload--disabled]="isImporting()">
+          <span>{{ isImporting() ? 'Importando...' : 'Selecionar arquivo CSV' }}</span>
+          <input type="file" accept=".csv,text/csv" (change)="importCsv($event)" [disabled]="isImporting()" />
+        </label>
+
+        <p class="reports-card__hint">
+          Tipos aceitos: <code>expense</code> e <code>income</code>. Valores decimais com ponto.
+        </p>
+      </section>
+
+      <section class="reports-card">
+        <header class="reports-card__header">
+          <h3>Exportar CSV</h3>
+          <p>Baixe um relatorio CSV com base nos filtros atuais.</p>
+        </header>
+
+        <form class="reports-form" [formGroup]="exportForm" (ngSubmit)="exportCsv()">
+          <label>
+            <span>Mes</span>
+            <input type="month" formControlName="month" />
+          </label>
+
+          <label>
+            <span>Categoria</span>
+            <select formControlName="category" [disabled]="isLoadingCategories()">
+              <option value="">Todas</option>
+              @for (category of categories(); track category.id) {
+                <option [value]="category.id">{{ category.name }}</option>
+              }
+            </select>
+          </label>
+
+          <button class="pf-btn pf-btn--primary" type="submit" [disabled]="isExporting()">
+            {{ isExporting() ? 'Exportando...' : 'Exportar CSV' }}
+          </button>
+        </form>
+
+        <p class="reports-card__hint">
+          O backend retorna um arquivo <code>transactions.csv</code> (ou nome customizado via header).
+        </p>
+      </section>
+    </div>
+  </article>
+</section>

--- a/frontend/src/app/pages/reports-page.component.ts
+++ b/frontend/src/app/pages/reports-page.component.ts
@@ -1,0 +1,169 @@
+import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { CategoriesService } from '../core/api/categories.service';
+import { Category, CsvImportResponse } from '../core/api/finance.models';
+import { ReportsService } from '../core/api/reports.service';
+import { ToastService } from '../core/ui/toast.service';
+
+@Component({
+  selector: 'app-reports-page',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './reports-page.component.html',
+  styleUrl: './reports-page.component.css'
+})
+export class ReportsPageComponent {
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly formBuilder = inject(FormBuilder);
+  private readonly categoriesService = inject(CategoriesService);
+  private readonly reportsService = inject(ReportsService);
+  private readonly toastService = inject(ToastService);
+
+  protected readonly categories = signal<Category[]>([]);
+  protected readonly isLoadingCategories = signal(true);
+  protected readonly isImporting = signal(false);
+  protected readonly isExporting = signal(false);
+  protected readonly pageError = signal<string | null>(null);
+  protected readonly lastImportResult = signal<CsvImportResponse | null>(null);
+
+  protected readonly exportForm = this.formBuilder.nonNullable.group({
+    month: [this.currentMonthRef()],
+    category: ['']
+  });
+
+  constructor() {
+    this.loadCategories();
+  }
+
+  protected downloadTemplate(): void {
+    const template = [
+      'date,description,amount,type,category',
+      '2026-02-26,Supermercado,123.45,expense,Alimentacao',
+      '2026-02-27,Salario,3500.00,income,Renda'
+    ].join('\n');
+
+    this.downloadBlob(new Blob([template], { type: 'text/csv;charset=utf-8' }), 'transactions-template.csv');
+    this.toastService.info('Modelo CSV baixado.');
+  }
+
+  protected importCsv(event: Event): void {
+    const input = event.target as HTMLInputElement | null;
+    const file = input?.files?.[0] ?? null;
+    if (!file || this.isImporting()) {
+      if (input) {
+        input.value = '';
+      }
+      return;
+    }
+
+    this.pageError.set(null);
+    this.isImporting.set(true);
+    this.reportsService
+      .importCsv(file)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (result) => {
+          this.isImporting.set(false);
+          this.lastImportResult.set(result);
+          this.toastService.success(`Importacao concluida: ${result.imported} importadas, ${result.skipped} ignoradas.`);
+          this.loadCategories();
+          if (input) {
+            input.value = '';
+          }
+        },
+        error: (error) => {
+          this.isImporting.set(false);
+          this.pageError.set(this.resolveErrorMessage(error, 'Nao foi possivel importar o CSV.'));
+          if (input) {
+            input.value = '';
+          }
+        }
+      });
+  }
+
+  protected exportCsv(): void {
+    if (this.isExporting()) {
+      return;
+    }
+
+    const filters = this.exportForm.getRawValue();
+    this.pageError.set(null);
+    this.isExporting.set(true);
+    this.reportsService
+      .exportCsv({
+        month: filters.month || null,
+        category: filters.category || null
+      })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (response) => {
+          this.isExporting.set(false);
+          const filename = this.resolveDownloadFilename(response.headers.get('content-disposition'), filters.month || null);
+          this.downloadBlob(response.body ?? new Blob([], { type: 'text/csv' }), filename);
+          this.toastService.success('CSV exportado com sucesso.');
+        },
+        error: (error) => {
+          this.isExporting.set(false);
+          this.pageError.set(this.resolveErrorMessage(error, 'Nao foi possivel exportar o CSV.'));
+        }
+      });
+  }
+
+  protected reloadCategories(): void {
+    this.loadCategories();
+  }
+
+  private loadCategories(): void {
+    this.isLoadingCategories.set(true);
+    this.categoriesService
+      .list()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (categories) => {
+          this.categories.set(categories);
+          this.isLoadingCategories.set(false);
+        },
+        error: (error) => {
+          this.pageError.set(this.resolveErrorMessage(error, 'Nao foi possivel carregar categorias.'));
+          this.isLoadingCategories.set(false);
+        }
+      });
+  }
+
+  private currentMonthRef(): string {
+    return new Date().toISOString().slice(0, 7);
+  }
+
+  private resolveErrorMessage(error: unknown, fallback: string): string {
+    if (error instanceof HttpErrorResponse) {
+      const apiError = error.error as { message?: unknown } | null;
+      if (typeof apiError?.message === 'string') {
+        return apiError.message;
+      }
+      if (error.status === 0) {
+        return 'Backend indisponivel.';
+      }
+    }
+    return fallback;
+  }
+
+  private resolveDownloadFilename(contentDisposition: string | null, month: string | null): string {
+    const match = contentDisposition?.match(/filename=\"?([^\";]+)\"?/i);
+    if (match?.[1]) {
+      return match[1];
+    }
+    return month ? `transactions-${month}.csv` : 'transactions.csv';
+  }
+
+  private downloadBlob(blob: Blob, filename: string): void {
+    const objectUrl = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = objectUrl;
+    anchor.download = filename;
+    anchor.click();
+    URL.revokeObjectURL(objectUrl);
+  }
+}


### PR DESCRIPTION
## Summary
- add dedicated /reports page for CSV import/export workflows
- add reports route and navigation item in the shell
- reuse ReportsService with import/export actions, template download and filter form

Closes #23

## Validation
- docker compose -f compose.dev.yml exec -T frontend npm run build
- Invoke-WebRequest http://localhost:34200/reports (200)
