### PR TITLE
feat: add reusable loading empty and error state components

### DIFF
--- a/frontend/src/app/pages/budgets-page.component.html
+++ b/frontend/src/app/pages/budgets-page.component.html
@@ -49,13 +49,13 @@
     </div>
 
     @if (loadError()) {
-      <p class="pf-inline-error" role="alert">{{ loadError() }}</p>
+      <app-state-error [message]="loadError()!" />
     }
 
     @if (isLoading()) {
-      <p class="pf-empty">Carregando metas...</p>
+      <app-state-loading message="Carregando metas..." />
     } @else if (!budgets().length) {
-      <p class="pf-empty">Nenhuma meta cadastrada para este mes.</p>
+      <app-state-empty message="Nenhuma meta cadastrada para este mes." />
     } @else {
       <div class="budgets__list">
         @for (budget of budgets(); track trackByBudgetId($index, budget)) {

--- a/frontend/src/app/pages/budgets-page.component.ts
+++ b/frontend/src/app/pages/budgets-page.component.ts
@@ -10,11 +10,14 @@ import { CategoriesService } from '../core/api/categories.service';
 import { Budget, Category, Transaction } from '../core/api/finance.models';
 import { TransactionsService } from '../core/api/transactions.service';
 import { ToastService } from '../core/ui/toast.service';
+import { StateEmptyComponent } from '../shared/state/state-empty.component';
+import { StateErrorComponent } from '../shared/state/state-error.component';
+import { StateLoadingComponent } from '../shared/state/state-loading.component';
 
 @Component({
   selector: 'app-budgets-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [CommonModule, ReactiveFormsModule, StateEmptyComponent, StateErrorComponent, StateLoadingComponent],
   templateUrl: './budgets-page.component.html',
   styleUrl: './budgets-page.component.css'
 })

--- a/frontend/src/app/pages/categories-page.component.html
+++ b/frontend/src/app/pages/categories-page.component.html
@@ -32,13 +32,13 @@
     </form>
 
     @if (loadError()) {
-      <p class="pf-inline-error" role="alert">{{ loadError() }}</p>
+      <app-state-error [message]="loadError()!" />
     }
 
     @if (isLoading()) {
-      <p class="pf-empty">Carregando categorias...</p>
+      <app-state-loading message="Carregando categorias..." />
     } @else if (!categories().length) {
-      <p class="pf-empty">Nenhuma categoria cadastrada ainda.</p>
+      <app-state-empty message="Nenhuma categoria cadastrada ainda." />
     } @else {
       <div class="categories__grid">
         @for (category of categories(); track trackByCategoryId($index, category)) {

--- a/frontend/src/app/pages/categories-page.component.ts
+++ b/frontend/src/app/pages/categories-page.component.ts
@@ -6,11 +6,14 @@ import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { CategoriesService } from '../core/api/categories.service';
 import { Category } from '../core/api/finance.models';
 import { ToastService } from '../core/ui/toast.service';
+import { StateEmptyComponent } from '../shared/state/state-empty.component';
+import { StateErrorComponent } from '../shared/state/state-error.component';
+import { StateLoadingComponent } from '../shared/state/state-loading.component';
 
 @Component({
   selector: 'app-categories-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [CommonModule, ReactiveFormsModule, StateEmptyComponent, StateErrorComponent, StateLoadingComponent],
   templateUrl: './categories-page.component.html',
   styleUrl: './categories-page.component.css'
 })

--- a/frontend/src/app/pages/dashboard-page.component.html
+++ b/frontend/src/app/pages/dashboard-page.component.html
@@ -12,11 +12,11 @@
   </header>
 
   @if (loadError()) {
-    <p class="pf-inline-error" role="alert">{{ loadError() }}</p>
+    <app-state-error [message]="loadError()!" />
   }
 
   @if (isLoading()) {
-    <p class="pf-empty">Carregando dashboard...</p>
+    <app-state-loading message="Carregando dashboard..." />
   } @else {
     <section class="metrics">
       @for (item of highlights(); track item.label) {
@@ -38,7 +38,7 @@
         </div>
 
         @if (!recentTransactions().length) {
-          <p class="pf-empty">Sem transacoes no mes atual.</p>
+          <app-state-empty message="Sem transacoes no mes atual." />
         } @else {
           <ul class="list">
             @for (tx of recentTransactions(); track tx.id) {
@@ -65,7 +65,7 @@
         </div>
 
         @if (!budgetSummary()) {
-          <p class="pf-empty">Nenhuma meta cadastrada neste mes.</p>
+          <app-state-empty message="Nenhuma meta cadastrada neste mes." />
         } @else {
           <div class="budget-summary">
             <p class="budget-summary__row">

--- a/frontend/src/app/pages/dashboard-page.component.ts
+++ b/frontend/src/app/pages/dashboard-page.component.ts
@@ -6,6 +6,9 @@ import { BudgetsService } from '../core/api/budgets.service';
 import { HealthService } from '../core/api/health.service';
 import { Budget, Transaction } from '../core/api/finance.models';
 import { TransactionsService } from '../core/api/transactions.service';
+import { StateEmptyComponent } from '../shared/state/state-empty.component';
+import { StateErrorComponent } from '../shared/state/state-error.component';
+import { StateLoadingComponent } from '../shared/state/state-loading.component';
 
 type HealthState = 'loading' | 'ok' | 'error';
 
@@ -18,7 +21,7 @@ interface DashboardHighlight {
 @Component({
   selector: 'app-dashboard-page',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, StateEmptyComponent, StateErrorComponent, StateLoadingComponent],
   templateUrl: './dashboard-page.component.html',
   styleUrl: './dashboard-page.component.css'
 })

--- a/frontend/src/app/pages/reports-page.component.html
+++ b/frontend/src/app/pages/reports-page.component.html
@@ -14,7 +14,7 @@
     </div>
 
     @if (pageError()) {
-      <p class="pf-inline-error" role="alert">{{ pageError() }}</p>
+      <app-state-error [message]="pageError()!" />
     }
 
     @if (lastImportResult()) {

--- a/frontend/src/app/pages/reports-page.component.ts
+++ b/frontend/src/app/pages/reports-page.component.ts
@@ -7,11 +7,12 @@ import { CategoriesService } from '../core/api/categories.service';
 import { Category, CsvImportResponse } from '../core/api/finance.models';
 import { ReportsService } from '../core/api/reports.service';
 import { ToastService } from '../core/ui/toast.service';
+import { StateErrorComponent } from '../shared/state/state-error.component';
 
 @Component({
   selector: 'app-reports-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [CommonModule, ReactiveFormsModule, StateErrorComponent],
   templateUrl: './reports-page.component.html',
   styleUrl: './reports-page.component.css'
 })

--- a/frontend/src/app/pages/transactions-page.component.html
+++ b/frontend/src/app/pages/transactions-page.component.html
@@ -91,13 +91,13 @@
     </form>
 
     @if (loadError()) {
-      <p class="pf-inline-error" role="alert">{{ loadError() }}</p>
+      <app-state-error [message]="loadError()!" />
     }
 
     @if (isLoading()) {
-      <p class="pf-empty">Carregando transacoes...</p>
+      <app-state-loading message="Carregando transacoes..." />
     } @else if (!(pageData()?.items?.length)) {
-      <p class="pf-empty">Nenhuma transacao encontrada para os filtros selecionados.</p>
+      <app-state-empty message="Nenhuma transacao encontrada para os filtros selecionados." />
     } @else {
       <div class="table-wrap">
         <table class="table">

--- a/frontend/src/app/pages/transactions-page.component.ts
+++ b/frontend/src/app/pages/transactions-page.component.ts
@@ -10,11 +10,14 @@ import { Category, PageResponse, Transaction, TransactionType } from '../core/ap
 import { ReportsService } from '../core/api/reports.service';
 import { TransactionsService } from '../core/api/transactions.service';
 import { ToastService } from '../core/ui/toast.service';
+import { StateEmptyComponent } from '../shared/state/state-empty.component';
+import { StateErrorComponent } from '../shared/state/state-error.component';
+import { StateLoadingComponent } from '../shared/state/state-loading.component';
 
 @Component({
   selector: 'app-transactions-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [CommonModule, ReactiveFormsModule, StateEmptyComponent, StateErrorComponent, StateLoadingComponent],
   templateUrl: './transactions-page.component.html',
   styleUrl: './transactions-page.component.css'
 })

--- a/frontend/src/app/shared/state/state-empty.component.ts
+++ b/frontend/src/app/shared/state/state-empty.component.ts
@@ -1,0 +1,10 @@
+import { Component, input } from '@angular/core';
+
+@Component({
+  selector: 'app-state-empty',
+  standalone: true,
+  template: `<p class="pf-empty">{{ message() }}</p>`
+})
+export class StateEmptyComponent {
+  readonly message = input.required<string>();
+}

--- a/frontend/src/app/shared/state/state-error.component.ts
+++ b/frontend/src/app/shared/state/state-error.component.ts
@@ -1,0 +1,10 @@
+import { Component, input } from '@angular/core';
+
+@Component({
+  selector: 'app-state-error',
+  standalone: true,
+  template: `<p class="pf-inline-error" role="alert">{{ message() }}</p>`
+})
+export class StateErrorComponent {
+  readonly message = input.required<string>();
+}

--- a/frontend/src/app/shared/state/state-loading.component.ts
+++ b/frontend/src/app/shared/state/state-loading.component.ts
@@ -1,0 +1,45 @@
+import { Component, input } from '@angular/core';
+
+@Component({
+  selector: 'app-state-loading',
+  standalone: true,
+  template: `
+    <p class="pf-empty state-loading" role="status" aria-live="polite">
+      <span class="state-loading__dot" aria-hidden="true"></span>
+      <span>{{ message() }}</span>
+    </p>
+  `,
+  styles: [
+    `
+      .state-loading {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.55rem;
+      }
+
+      .state-loading__dot {
+        width: 0.5rem;
+        height: 0.5rem;
+        border-radius: 999px;
+        background: var(--accent);
+        box-shadow: 0 0 0 0 rgba(82, 214, 165, 0.35);
+        animation: state-pulse 1000ms ease-out infinite;
+      }
+
+      @keyframes state-pulse {
+        0% {
+          transform: scale(1);
+          box-shadow: 0 0 0 0 rgba(82, 214, 165, 0.35);
+        }
+
+        100% {
+          transform: scale(1.15);
+          box-shadow: 0 0 0 8px rgba(82, 214, 165, 0);
+        }
+      }
+    `
+  ]
+})
+export class StateLoadingComponent {
+  readonly message = input('Carregando...');
+}


### PR DESCRIPTION
## Summary\n- create standalone state components for loading, empty and error states\n- apply them to dashboard, transactions, budgets, reports and categories\n- keep page-specific error variants where extra styling is needed\n\nCloses #19