### PR TITLE
test(frontend): expand shell UI tests for mobile nav state

### DIFF
--- a/frontend/src/app/layout/shell-layout.component.spec.ts
+++ b/frontend/src/app/layout/shell-layout.component.spec.ts
@@ -66,4 +66,44 @@ describe('ShellLayoutComponent', () => {
     expect(toastServiceMock.info).toHaveBeenCalledWith('Sessao encerrada.');
     expect(navigateSpy).toHaveBeenCalledWith('/login');
   });
+
+  it('should open and close mobile nav from toggle and backdrop', () => {
+    const fixture = TestBed.createComponent(ShellLayoutComponent);
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    const menuToggle = host.querySelector('button[aria-controls="pf-mobile-nav"]') as HTMLButtonElement;
+    expect(menuToggle.getAttribute('aria-expanded')).toBe('false');
+
+    menuToggle.click();
+    fixture.detectChanges();
+
+    expect(menuToggle.getAttribute('aria-expanded')).toBe('true');
+    expect(host.querySelector('.shell__sidebar')?.classList.contains('shell__sidebar--open')).toBeTrue();
+    expect(host.querySelector('.shell__backdrop')).not.toBeNull();
+
+    (host.querySelector('.shell__backdrop') as HTMLButtonElement).click();
+    fixture.detectChanges();
+
+    expect(menuToggle.getAttribute('aria-expanded')).toBe('false');
+    expect(host.querySelector('.shell__sidebar')?.classList.contains('shell__sidebar--open')).toBeFalse();
+    expect(host.querySelector('.shell__backdrop')).toBeNull();
+  });
+
+  it('should close mobile nav when a nav link is clicked', () => {
+    const fixture = TestBed.createComponent(ShellLayoutComponent);
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    const menuToggle = host.querySelector('button[aria-controls="pf-mobile-nav"]') as HTMLButtonElement;
+    menuToggle.click();
+    fixture.detectChanges();
+
+    const firstNavLink = host.querySelector('.nav__link') as HTMLAnchorElement;
+    firstNavLink.click();
+    fixture.detectChanges();
+
+    expect(menuToggle.getAttribute('aria-expanded')).toBe('false');
+    expect(host.querySelector('.shell__sidebar')?.classList.contains('shell__sidebar--open')).toBeFalse();
+  });
 });


### PR DESCRIPTION
## Summary\n- add tests for mobile menu open/close via toggle and backdrop\n- add tests to verify menu closes when a nav link is clicked\n- keep existing logout and nav icon coverage\n\n## Validation\n- docker compose -f compose.dev.yml exec -T frontend npm run spec:check\n- docker compose -f compose.dev.yml exec -T frontend npm run build\n- docker compose -f compose.dev.yml exec -T frontend npm run test:ci *(local container sem ChromeHeadless binario; esperado)*\n\nCloses #90\n