### PR TITLE
ci: run visual smoke and upload screenshot artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,10 @@ jobs:
     name: Visual Smoke (Docker + Screenshots)
     runs-on: ubuntu-latest
     needs: [backend, frontend]
+    env:
+      POSTGRES_PORT: 35432
+      BACKEND_PORT: 38080
+      FRONTEND_PORT: 34200
 
     steps:
       - name: Checkout
@@ -74,7 +78,7 @@ jobs:
       - name: Wait for services
         run: |
           for i in {1..120}; do
-            if curl -fsS http://localhost:8080/actuator/health >/dev/null && curl -fsS http://localhost:4200 >/dev/null; then
+            if curl -fsS http://localhost:38080/actuator/health >/dev/null && curl -fsS http://localhost:34200 >/dev/null; then
               echo "Services are up"
               exit 0
             fi
@@ -85,7 +89,7 @@ jobs:
           exit 1
 
       - name: Run visual smoke script
-        run: pwsh -File ./scripts/visual-smoke.ps1 -FrontendUrl "http://localhost:4200" -BackendUrl "http://localhost:8080" -OutDir "./artifacts/smoke"
+        run: pwsh -File ./scripts/visual-smoke.ps1 -FrontendUrl "http://localhost:34200" -BackendUrl "http://localhost:38080" -OutDir "./artifacts/smoke"
 
       - name: Upload visual smoke artifacts
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,47 @@ jobs:
           npm run spec:check
           npm run test:ci
           npm run build
+
+  visual-smoke:
+    name: Visual Smoke (Docker + Screenshots)
+    runs-on: ubuntu-latest
+    needs: [backend, frontend]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Start docker stack
+        run: docker compose -f compose.dev.yml up -d db backend frontend
+
+      - name: Wait for services
+        run: |
+          for i in {1..120}; do
+            if curl -fsS http://localhost:8080/actuator/health >/dev/null && curl -fsS http://localhost:4200 >/dev/null; then
+              echo "Services are up"
+              exit 0
+            fi
+            sleep 3
+          done
+          echo "Services did not become healthy in time"
+          docker compose -f compose.dev.yml ps
+          exit 1
+
+      - name: Run visual smoke script
+        run: pwsh -File ./scripts/visual-smoke.ps1 -FrontendUrl "http://localhost:4200" -BackendUrl "http://localhost:8080" -OutDir "./artifacts/smoke"
+
+      - name: Upload visual smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-smoke-${{ github.run_id }}
+          path: artifacts/smoke
+          if-no-files-found: warn
+
+      - name: Dump compose logs on failure
+        if: failure()
+        run: docker compose -f compose.dev.yml logs --tail 200
+
+      - name: Stop docker stack
+        if: always()
+        run: docker compose -f compose.dev.yml down -v

--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ node scripts/capture-readme-prints.mjs
 - A CI valida:
   - `backend`: `mvn test`
   - `frontend`: `npm run build`
+  - `visual-smoke`: sobe stack Docker dev, executa `scripts/visual-smoke.ps1` e publica screenshots como artifact
 - O Angular usa budgets de bundle/estilo para sinalizar crescimento excessivo.
 - Os limites de `anyComponentStyle` foram ajustados para um patamar mais realista do layout atual, mantendo alerta sem gerar ruído excessivo no dia a dia.
 

--- a/scripts/visual-smoke.ps1
+++ b/scripts/visual-smoke.ps1
@@ -7,20 +7,40 @@ param(
 $ErrorActionPreference = "Stop"
 
 function Resolve-ChromePath {
-  $candidates = @(
-    "C:\Program Files\Google\Chrome\Application\chrome.exe",
-    "C:\Program Files (x86)\Google\Chrome\Application\chrome.exe",
-    "C:\Program Files\Microsoft\Edge\Application\msedge.exe",
-    "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe"
-  )
+  $isWindowsHost = (($PSVersionTable.PSEdition -eq "Desktop") -or ($env:OS -eq "Windows_NT") -or $IsWindows)
 
-  foreach ($candidate in $candidates) {
-    if (Test-Path $candidate) {
-      return $candidate
+  if ($isWindowsHost) {
+    $candidates = @(
+      "C:\Program Files\Google\Chrome\Application\chrome.exe",
+      "C:\Program Files (x86)\Google\Chrome\Application\chrome.exe",
+      "C:\Program Files\Microsoft\Edge\Application\msedge.exe",
+      "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe"
+    )
+
+    foreach ($candidate in $candidates) {
+      if (Test-Path $candidate) {
+        return $candidate
+      }
+    }
+  } else {
+    $commands = @(
+      "google-chrome",
+      "google-chrome-stable",
+      "chromium-browser",
+      "chromium",
+      "microsoft-edge",
+      "microsoft-edge-stable"
+    )
+
+    foreach ($commandName in $commands) {
+      $command = Get-Command $commandName -ErrorAction SilentlyContinue
+      if ($command -and $command.Path) {
+        return $command.Path
+      }
     }
   }
 
-  throw "Nao foi encontrado Chrome/Edge para captura headless."
+  throw "Nao foi encontrado Chrome/Edge para captura headless neste ambiente."
 }
 
 function Capture-Screenshot {


### PR DESCRIPTION
## Summary\n- add isual-smoke job in CI after backend/frontend jobs\n- start docker stack in workflow, run scripts/visual-smoke.ps1, upload screenshots as artifacts\n- improve Resolve-ChromePath to support Windows PowerShell, PowerShell Core, and Linux runners\n- document CI visual-smoke stage in README\n\n## Validation\n- powershell -ExecutionPolicy Bypass -File .\\scripts\\visual-smoke.ps1\n\nCloses #91\n